### PR TITLE
Add --no-ri --no-rdoc to "gem i" as well

### DIFF
--- a/_posts/2013-05-02-install.markdown
+++ b/_posts/2013-05-02-install.markdown
@@ -99,7 +99,7 @@ rbenv global 2.1.1
 3-B-6. 安裝 rails:
 
 {% highlight sh %}
-gem install rails
+gem install rails --no-ri --no-rdoc
 {% endhighlight %}
 
 **最後一步** 妳會需要文字編輯器來編輯程式碼檔案。我們推薦使用 Sublime Text 編輯器。


### PR DESCRIPTION
This matches the flags used in line 42:

   gem update rails --no-ri --no-rdoc

Without these flags, OS X 10.9 users could run into:

```
https://github.com/rails/rails/issues/11814
```

where installation seems to hang.

( Also sent to upstream as https://github.com/railsgirls/railsgirls.github.com/pull/162 )
